### PR TITLE
Adiciona @Enumerated(EnumType.STRING) no campo produto da entidade Estoque

### DIFF
--- a/estoque/src/main/java/com/tjportas/estoque/entity/Estoque.java
+++ b/estoque/src/main/java/com/tjportas/estoque/entity/Estoque.java
@@ -1,6 +1,8 @@
 package com.tjportas.estoque.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,7 +26,10 @@ public class Estoque {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private Long codigo;
+
+    @Enumerated(EnumType.STRING)
     private Produto produto;
+    
     private String modelo;
     private String fornecedor;
     private Integer quantidade;


### PR DESCRIPTION
No campo produto eu utilizei a anotação @Enumerated(EnumType.STRING) para mapear corretamente o tipo enum. Isso garante que no banco de dados o valor seja salvo como texto (PORTA, JANELA, FECHADURA), o que melhora a legibilidade e evita problemas de inconsistência caso a ordem dos enums mude no código. Essa prática é considerada a mais segura quando usamos enums em entidades JPA.